### PR TITLE
1.1 Installation: mentioning `--unsafe-perm` npm param

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ $ npm --global install balena-cli
 ```
 This will install the balenaCLI globally and allow you to run it in a terminal
 via `balena <command>`. Note that, depending on how you've installed NodeJS
-and NPM, you may need to prefix this command with `sudo`.
+and NPM, you may need to prefix this command with `sudo`. Also, if you get an
+error such as `EACCES: permission denied`, add param `--unsafe-perm` right
+after `--global`
 
 ### 1.2 Authentication
 


### PR DESCRIPTION
Add `--unsafe-perm` param to npm command line if you get a `EACCESS permission denied` error

`--unsafe-perm` is [mentioned here](https://github.com/balena-io/balena-cli/blob/master/INSTALL.md#npm-installation) and without it, installation fails on my linux box (I don't use `nvm`)

Change-type: patch
Signed-off-by: Federico Fissore <federico@fissore.org>